### PR TITLE
Substitute Atomics.notify() for Atomics.wake()

### DIFF
--- a/audio-worklet/design-pattern/shared-buffer/shared-buffer-worker.js
+++ b/audio-worklet/design-pattern/shared-buffer/shared-buffer-worker.js
@@ -29,7 +29,7 @@
 
 // Indices for the State SAB.
 const STATE = {
-  // Flag for Atomics.wait() and wake().
+  // Flag for Atomics.wait() and notify().
   'REQUEST_RENDER': 0,
 
   // Available frames in Input SAB.

--- a/audio-worklet/design-pattern/shared-buffer/shared-buffer-worklet-processor.js
+++ b/audio-worklet/design-pattern/shared-buffer/shared-buffer-worklet-processor.js
@@ -142,7 +142,7 @@ class SharedBufferWorkletProcessor extends AudioWorkletProcessor {
 
     if (this._states[STATE.IB_FRAMES_AVAILABLE] >= this._kernelLength) {
       // Now we have enough frames to process. Wake up the worker.
-      Atomics.wake(this._states, STATE.REQUEST_RENDER, 1);
+      Atomics.notify(this._states, STATE.REQUEST_RENDER, 1);
     }
 
     return true;


### PR DESCRIPTION
shared-buffer-worklet-processor.js:145 [Deprecation] Atomics.wake is deprecated and will be removed in M76, around July 2019. Please use Atomics.notify instead. See https://www.chromestatus.com/features/6228189936353280 for more details.

Rename Atomics.wake() to Atomics.notify()
  
The Atomics.wake() method is being renamed Atomics.notify(). This is a low-level function to wake a Worker that has been suspended via Atomics.wait(). This conforms to a specification change made to alleviate confusion created by the similarity of the names wait and wake.